### PR TITLE
terraform-equinix-fabric-aws module initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+*.dll
+*.exe
+.DS_Store
+example.tf
+terraform.tfplan
+terraform.tfstate
+bin/
+modules-dev/
+/pkg/
+website/.vagrant
+website/.bundle
+website/build
+website/node_modules
+.vagrant/
+*.backup
+./*.tfstate
+.terraform/
+*.log
+*.bak
+*~
+.*.swp
+.idea
+.vscode
+*.iml
+*.test
+*.iml
+
+website/vendor
+
+# Test exclusions
+!command/test-fixtures/**/*.tfstate
+!command/test-fixtures/**/.terraform/
+
+# Ignore provider's binary
+terraform-provider-equinix

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Equinix Fabric connection: AWS Direct Connect
+
+A Terraform module to create Equinix Fabric layer 2 connection between:
+
+* Fabric's port, or
+* Network Edge virtual device
+
+and Amazon Web Services using AWS Direct Connect hosted connection.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.0 |
+| equinix | >= 1.0.0 |
+
+## Providers
+
+| Name | Version |
+|---------|----------|
+| equinix | >= 1.0.0 |
+
+## Example usage
+
+Check [examples](examples/) directory
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+|name|Name of the connection|`string`|`""`|yes|
+|purchase_order_number|Purchase order number to link with connection on the invoice|`string`|`""`|no|
+|notifications|List of email addresses that will receive notifications about connection|`list(string)`|n/a|yes|
+|port_id|Equinix Fabric port identifier for the connection source (connection's a-side)|`string`|`""`|no|
+|vlan_stag|Connection's vlan s-tag (outer tag)|`number`|`0`|no|
+|vlan_ctag|Connection's vlan c-tag (inner tag)|`number`|`0`|no|
+|device_id|Equinix Network Edge virtual device identifier for the connection source (connection's a-side)|`string`|`""`|no|
+|device_interface_id|Equinix Network Edge virtual device interface identifier for the connection source (connection's a-side)|`string`|`""`|no|
+|speed|Connection speed|`number`|`0`|yes|
+|speed_unit|Connection speed unit|`string`|`""`|yes|
+|aws_account_id|AWS account identifier|`string`|`""`|yes|
+|aws_access_key|AWS access key|`string`|`""`|yes|
+|aws_secret_key|AWS secret key|`string`|`""`|yes|
+|aws_metro_code|Equinix metro code of AWS Direct Connect location|`string`|`""`|yes|
+|aws_region|AWS Region associated with AWS Direct Connect location|`string`|`""`|yes|
+
+### AWS Direct Connect metros and regions
+
+Please check AWS Direct Connect Locations on official [AWS Direct COnnection Features
+page](https://aws.amazon.com/directconnect/features) for details about possible
+values of `aws_metro_code` and `aws_region` arguments.
+
+## Outputs
+
+## AWS Direct Connect Locations
+
+| Name | Description |
+|------|-------------|
+|sp_name|Name of Equinix Fabric seller service profile used for a connection|
+|id|Connection identifier|
+|status|Connection provisioning status|
+|provider_status|Connection provider status|
+|zside_port_id|Equinix Fabric port identifier on the connection's remote side (z-side)|
+|zside_vlan_stag|Vlan s-tag (outer tag) on the remote side (z-side) of the connection|
+|zside_vlan_ctag|Vlan c-tag (inner tag) on the remote side (z-side) of the connection|
+|aws_connection_id|The ID of the Direct Connect connection on AWS side|

--- a/examples/fabric_port_to_aws/README.md
+++ b/examples/fabric_port_to_aws/README.md
@@ -1,0 +1,53 @@
+# Equinix Fabric connection: port to AWS virtual private interface
+
+This example shows how to create layer2 connection between Equinix Fabric port and
+AWS Direct Connect virtual private interface.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+|equinix_client_id|Equinix client ID (consumer key) from the app registered in Equinix Developer Portal|`string`|`""`|yes|
+|equinix_client_secret|Equinix client secret (consumer secret) from the app registered in Equinix Developer Portal|`string`|`""`|yes|
+|equinix_port_name|Name of the Equinix Fabric port to use on connection's originating side (a-zide)|`string`|`""`|yes|
+|aws_account_id|AWS account identifier|`string`|`""`|yes|
+|aws_access_key|AWS access key|`string`|`""`|yes|
+|aws_secret_key|AWS secret key|`string`|`""`|yes|
+|aws_metro_code|Equinix metro code of AWS Direct Connect location|`string`|`"SV"`|no|
+|aws_region|AWS Region associated with AWS Direct Connect location|`string`|`"us-west-1"`|no|
+|connection_name|Connection name|`string`|`"example"`|no|
+|connection_speed|Connection speed|`number`|`1`|no|
+|connection_speed_unit|Connection speed unit (`"GB"` or `"MB"`)|`string`|`"GB"`|no|
+|notifications|List of email addresses that will receive notifications about the connection|`list(string)`|n/a|yes|
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+|sp_name|Name of Equinix Fabric seller service profile used for a connection|
+|id|Equinix Fabric connection identifier|
+|aws_connection_id|AWS Direct Connect connection identifier|
+|aws_virtual_interface_id|The ID of the Direct Connect hosted private virtual interface|
+|aws_vpc_id|The ID of the AWS VPC|
+|aws_vpn_gateway_id|The ID of the AWS VPN gateway|
+
+## Usage
+
+1. Adjust variables
+2. Initialize
+
+   ```sh
+   terraform init
+   ```
+
+3. Check plan
+
+   ```sh
+   terraform plan
+   ```
+
+4. Apply changes
+
+   ```sh
+   terraform apply
+   ```

--- a/examples/fabric_port_to_aws/main.tf
+++ b/examples/fabric_port_to_aws/main.tf
@@ -1,0 +1,50 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}
+
+data "equinix_ecx_port" "port" {
+  name = var.equinix_port_name
+}
+
+module "aws-connection" {
+  source         = "../../"
+  name           = var.connection_name
+  notifications  = var.notifications
+  port_id        = data.equinix_ecx_port.port.id
+  vlan_stag      = var.connection_vlan_stag
+  vlan_ctag      = var.connection_vlan_ctag == 0 ? null : var.connection_vlan_ctag
+  speed          = var.connection_speed
+  speed_unit     = var.connection_speed_unit
+  aws_metro_code = var.aws_metro_code
+  aws_region     = var.aws_region
+  aws_account_id = var.aws_account_id
+  aws_access_key = var.aws_access_key
+  aws_secret_key = var.aws_secret_key
+}
+
+resource "aws_dx_private_virtual_interface" "example" {
+  connection_id    = module.aws-connection.aws_connection_id
+  name             = var.connection_name
+  vlan             = var.connection_vlan_stag
+  address_family   = "ipv4"
+  bgp_asn          = 64999
+  amazon_address   = "169.254.0.1/30"
+  customer_address = "169.254.0.2/30"
+  bgp_auth_key     = "secret"
+  vpn_gateway_id   = aws_vpn_gateway.example.id
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.255.255.0/28"
+}
+
+resource "aws_vpn_gateway" "example" {
+  vpc_id = aws_vpc.example.id
+}

--- a/examples/fabric_port_to_aws/outputs.tf
+++ b/examples/fabric_port_to_aws/outputs.tf
@@ -1,0 +1,29 @@
+output "sp_name" {
+  description = "Name of Equinix Fabric seller service profile used for a connection"
+  value       = module.aws-connection.sp_name
+}
+
+output "id" {
+  description = "Connection identifier"
+  value       = module.aws-connection.id
+}
+
+output "aws_connection_id" {
+  description = "The ID of the Direct Connect connection on AWS side"
+  value       = module.aws-connection.aws_connection_id
+}
+
+output "aws_virtual_interface_id" {
+  description = "The ID of the Direct Connect hosted private virtual interface"
+  value       = aws_dx_private_virtual_interface.example.id
+}
+
+output "aws_vpc_id" {
+  description = "The ID of the AWS VPC"
+  value       = aws_vpc.example.id
+}
+
+output "aws_vpn_gateway_id" {
+  description = "The ID of the AWS VPN gateway"
+  value       = aws_vpn_gateway.example.id
+}

--- a/examples/fabric_port_to_aws/variables.tf
+++ b/examples/fabric_port_to_aws/variables.tf
@@ -1,0 +1,60 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key) from the app registered in Equinix Developer Portal"
+}
+
+variable "equinix_client_secret" {
+  description = "Equinix client secret (consumer secret) from the app registered in Equinix Developer Portal"
+}
+
+variable "equinix_port_name" {
+  description = "Name of the Equinix Fabric port to use on connection's originating side (a-zide)"
+}
+
+variable "connection_name" {
+  description = "Connection name"
+  default     = "example"
+}
+
+variable "connection_speed" {
+  description = "Connection speed"
+  default     = 1
+}
+
+variable "connection_speed_unit" {
+  description = "Connection speed"
+  default     = "GB"
+}
+
+variable "connection_vlan_stag" {
+  description = "Connection vlan s-tag (outer tag)"
+}
+
+variable "connection_vlan_ctag" {
+  description = "Connection vlan c-tag (inner tag)"
+}
+
+variable "notifications" {
+  description = "List of email addresses that will receive notifications about the connection"
+}
+
+variable "aws_account_id" {
+  description = "AWS account identifier"
+}
+
+variable "aws_access_key" {
+  description = "AWS access key"
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret key"
+}
+
+variable "aws_metro_code" {
+  description = "Equinix metro code of AWS Direct Connect location"
+  default     = "SV"
+}
+
+variable "aws_region" {
+  description = "AWS region for connection destination and AWS resources"
+  default     = "us-west-1"
+}

--- a/examples/fabric_port_to_aws/versions.tf
+++ b/examples/fabric_port_to_aws/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 1.0"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,26 @@
+data "equinix_ecx_l2_sellerprofile" "this" {
+  name = var.speed_unit == "GB" ? "AWS Direct Connect - High Capacity" : "AWS Direct Connect"
+}
+
+resource "equinix_ecx_l2_connection" "this" {
+  name                  = var.name
+  purchase_order_number = length(var.purchase_order_number) > 0 ? var.purchase_order_number : null
+  profile_uuid          = data.equinix_ecx_l2_sellerprofile.this.id
+  speed                 = var.speed
+  speed_unit            = var.speed_unit
+  notifications         = var.notifications
+  port_uuid             = length(var.port_id) > 0 ? var.port_id : null
+  device_uuid           = length(var.device_id) > 0 ? var.device_id : null
+  device_interface_id   = var.device_interface_id == 0 ? null : var.device_interface_id
+  vlan_stag             = var.vlan_stag == 0 ? null : var.vlan_stag
+  vlan_ctag             = var.vlan_ctag == 0 ? null : var.vlan_ctag
+  seller_region         = var.aws_region
+  seller_metro_code     = var.aws_metro_code
+  authorization_key     = var.aws_account_id
+}
+
+resource "equinix_ecx_l2_connection_accepter" "this" {
+  connection_id = equinix_ecx_l2_connection.this.id
+  access_key    = var.aws_access_key
+  secret_key    = var.aws_secret_key
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,39 @@
+output "sp_name" {
+  description = "Name of Equinix Fabric seller service profile used for a connection"
+  value       = data.equinix_ecx_l2_sellerprofile.this.name
+}
+
+output "id" {
+  description = "Connection identifier"
+  value       = equinix_ecx_l2_connection.this.id
+}
+
+output "status" {
+  description = "Connection provisioning status"
+  value       = equinix_ecx_l2_connection.this.status
+}
+
+output "provider_status" {
+  description = "Connection provider status"
+  value       = equinix_ecx_l2_connection.this.provider_status
+}
+
+output "zside_port_id" {
+  description = "Equinix Fabric port identifier on the z-side of the connection"
+  value       = equinix_ecx_l2_connection.this.zside_port_uuid
+}
+
+output "zside_vlan_stag" {
+  description = "Vlan s-tag (outer tag) on the z-side of the connection"
+  value       = equinix_ecx_l2_connection.this.zside_vlan_stag
+}
+
+output "zside_vlan_ctag" {
+  description = "Vlan c-tag (inner tag) on the z-side of the connection"
+  value       = equinix_ecx_l2_connection.this.zside_vlan_ctag
+}
+
+output "aws_connection_id" {
+  description = "The ID of the Direct Connect connection on AWS side"
+  value       = equinix_ecx_l2_connection_accepter.this.aws_connection_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,92 @@
+variable "name" {
+  description = "Connection name"
+  type        = string
+}
+
+variable "purchase_order_number" {
+  description = "Purchase order number to link with connection on the invoice"
+  type        = string
+  default     = ""
+}
+
+variable "notifications" {
+  description = "List of email addresses that will receive notifications about connection"
+  type        = list(string)
+  validation {
+    condition     = length(var.notifications) > 0
+    error_message = "Notification list should contain at least one email address."
+  }
+}
+
+variable "port_id" {
+  description = "Equinix Fabric port identifier for connection source (a-side)"
+  type        = string
+  default     = ""
+}
+
+variable "vlan_stag" {
+  description = "Connection vlan s-tag (outer tag)"
+  type        = number
+  default     = 0
+}
+
+variable "vlan_ctag" {
+  description = "Vlan c-tag (inner tag)"
+  type        = number
+  default     = 0
+}
+
+variable "device_id" {
+  description = "Equinix Network Edge virtual device identifier for connection source (a-side)"
+  type        = string
+  default     = ""
+}
+
+variable "device_interface_id" {
+  description = "Equinix Network Edge virtual device interface identifier connection source (a-side)"
+  type        = number
+  default     = 0
+}
+
+variable "speed" {
+  description = "Connection speed"
+  type        = number
+}
+
+variable "speed_unit" {
+  description = "Connection speed unit"
+  type        = string
+  validation {
+    condition     = can(regex("^(MB|GB)$", var.speed_unit))
+    error_message = "Speed unit should be either MB (for Mbps) or GB (for Gbps)."
+  }
+}
+
+variable "aws_account_id" {
+  description = "AWS account identifier"
+  type        = string
+}
+
+variable "aws_access_key" {
+  description = "AWS access key"
+  type        = string
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret key"
+  type        = string
+}
+
+variable "aws_metro_code" {
+  description = "Equinix metro code of AWS Direct Connect location"
+  type        = string
+  validation {
+    condition     = can(regex("^[A-Z]{2}$", var.aws_metro_code))
+    error_message = "Valid metro code consits of two capital letters, i.e. SV, DC."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS Region associated with AWS Direct Connect location"
+  type        = string
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 1.0"
+    }
+  }
+}


### PR DESCRIPTION
Initial commit for terraform-equinix-fabric-aws module.
Goal of this module is to create layer two connection between Fabric's port or Network Edge device and AWS, using AWS Direct Connect hosted connection.

PR provides module files plus one example of using it with Equinix Fabric port on connection originating side (a-side).